### PR TITLE
Update document for toolchain release v0.21.0.

### DIFF
--- a/docs/toolchain/appendix/command_line.md
+++ b/docs/toolchain/appendix/command_line.md
@@ -2,7 +2,9 @@
 
 ## 0. Introduction
 
-Since toolchain version v0.14.0, we introduce Python API and recommend using it for the general work flow. But this doesn't mean that the old approad of script utilities are abandoned. This document provides the usage of all the script utilities. Note that 530 only has the IP evaluator script. For other tools, please refer to the toolchain document.
+Since toolchain version v0.14.0, we introduce Python API and recommend using it for the general work flow. This document provides the usage of all the script utilities. Note that 530 only has the IP evaluator script. For other tools, please refer to the toolchain document.
+
+Since toolchain version v0.21.0, most of the command line scripts are removed. Please use the Python API instead.
 
 ### 1. IP Evaluator
 
@@ -35,90 +37,17 @@ We can find the following files after running the script above:
 * `/data1/compiler/command.bin`: the compiled binary for the hardware.
 * `/data1/compiler/setup.bin`: the compiled binary for the hardware.
 * `/data1/compiler/weight.bin`: the compiled binary for the hardware.
-* `/data1/compiler/ioinfo.csv`: the hardware IO mapping information of the model.
+* `/data1/compiler/ioinfo.csv`: the hardware IO mapping information of the model for 520.
+* `/data1/compiler/ioinfo.json`: the hardware IO mapping information of the model for other hardware platforms.
 * `/data1/compiler/ip_eval_prof.txt`:  the IP evaluation report, which is the estimate performance of your model on the NPU. *(Only the 520 version script generate this file.)*
 * `/data1/compiler/ProfileResult.txt`:  the IP evaluation report, which is the estimate performance of your model on the NPU. *(Only the 720 version script generate this file.)*
 
 
-### 2 FpAnalyser, Compiler and IpEvaluator
-
-In this section and the following sections, we'll use the `LittleNet` as an example. You can find the folder under
-`/workspace/examples`. To use it, copy it under `/data1`.
-
-```bash
-cp -r /workspace/examples/LittleNet /data1
-cp /data1/LittleNet/input_params.json /data1
-```
-
-#### 2.1 Prepare the input
-
-Before running the programs, you need to prepare the inputs. In our toolchain, all the outputs are placed under `/data1`.
-We call it the Interactivate Folder. So, we recommend you create this folder if it is not already there. Then we need to
-configure the input parameters using `input_params.json` for the toolchain under `/data1`. As an example,
-`input_params.json` for `LittleNet` model is under `/data1/LittleNet`, if you have already copy the folder as described
-in the beginning of section 2. You already has the `input_params.json` ready. You can see the detailed explanation
-for the input parameters in appendix A.
-
-> The `input_params.json` is different in 0.10.0. Please check the FAQ for new config fields or use section 6.3 to
-> upgrade your existed `input_params.json`.
-
-#### 2.2 Running the program
-
-After preparing `input_params.json`, you can run the programs by the following command:
-
-```bash
-# For KDP520
-# python /workspace/scripts/fpAnalyserCompilerIpevaluator_520.py -t thread_number
-python /workspace/scripts/fpAnalyserCompilerIpevaluator_520.py -t 8
-
-# For KDP720
-# python /workspace/scripts/fpAnalyserCompilerIpevaluator_720.py -t thread_number
-python /workspace/scripts/fpAnalyserCompilerIpevaluator_720.py -t 8
-```
-
-`thread_number`: the number of thread to use.
-
-#### 2.3 Get the result
-
-After running this program, the folders called `compiler` and `fpAnalyser` will be generated under `/data1`. `compiler` stores the result of compiler and ipEvaluator. `fpAnalyser` stores the result of the model analyzer.
-
-We can find the following files after running the script above:
-
-* `/data1/fpAnalyser/<model_name>.quan.wqbi.bie`: the encrypted result of the model analyzer. It includes the quantize information and the model itself. Can be taken by the compiler and the simulator.
-* `/data1/compiler/command.bin`: the compiled binary for the hardware.
-* `/data1/compiler/setup.bin`: the compiled binary for the hardware.
-* `/data1/compiler/weight.bin`: the compiled binary for the hardware.
-* `/data1/compiler/ioinfo.csv`: the hardware IO mapping information of the model.
-* `/data1/compiler/ip_eval_prof.txt`:  the IP evaluation report, which is the estimate performance of your model on the NPU. *(Only the 520 version script generate this file.)*
-* `/data1/compiler/ProfileResult.txt`:  the IP evaluation report, which is the estimate performance of your model on the NPU. *(Only the 720 version script generate this file.)*
-
-### 3 Hardware validation (optional)
-
-#### 3.1 Run hardware validate script.
-
-This step will make sure whether the mathematical simulator’s result is the same as the hardware simulator’s. In other
-words, this step makes sure the model can run correctly on the hardware.
-
-```bash
-# For KDP520
-python /workspace/scripts/hardware_validate_520.py
-
-# For KDP720
-python /workspace/scripts/hardware_validate_720.py
-```
-
-If it succeeds, you can the command line print out log: `[info] hardware validating successes!`. Otherwise, you might need to check your model to see if it has passed the converter. If the problem persist, please ask our stuff for help and provide the simulator result and the hardware simulator result under `/data1/simulator` and `/data1/c_sim`.
-
-#### 3.2 Simulator and Emulator
-
-One can also run simulator manually to get the result and check if it meets the need. This part is descibed in the end to end simulator document. Please check.
-
-
-### 4 Batch-Compile
+### 2 Batch-Compile
 
 This part is the instructions for batch-compile, which will generate the binary file requested by firmware with the `bie` files given.
 
-#### 4.1 Fill the input parameters
+#### 2.1 Fill the input parameters
 
 Fill the input parameters in the `/data1/batch_input_params.json` under `/data1`. Please refer to the appendix B to fill the related parameters.
 
@@ -163,7 +92,8 @@ Under `/data1`, you’ll find a folder called `batch_compile`, which contains th
 * `/data1/batch_compile/<model_name>.command.bin`: the compiled binary for the hardware of a single model. You might find one for every model you list in the json.
 * `/data1/batch_compile/<model_name>.setup.bin`: the compiled binary for the hardware of a single model. You might find one for every model you list in the json.
 * `/data1/batch_compile/<model_name>.weight.bin`: the compiled binary for the hardware of a single model. You might find one for every model you list in the json.
-* `/data1/batch_compile/<model_name>.ioinfo.csv`: the hardware IO mapping information of the model. You might find one for every model you list in the json.
+* `/data1/batch_compile/<model_name>.ioinfo.csv`: the hardware IO mapping information of the model. You might find one for every model you list in the json. (520)
+* `/data1/batch_compile/<model_name>.ioinfo.json`: the hardware IO mapping information of the model. You might find one for every model you list in the json.
 * `/data1/batch_compile/models_520.nef`: the compiled binary with all the models. This file is designed to be loaded by the firmware. *(Only the 520 version script generate this file.)*
 * `/data1/batch_compile/models_720.nef`: the compiled binary with all the models. This file is designed to be loaded by the firmware. *(Only the 720 version script generate this file.)*
 
@@ -199,92 +129,21 @@ The `/data1/batch_input_params.json` is just like in section 4.1, but with one m
 The command is the same as in section 4.2 and the results are `.bin` files for each model and on `.nef` file like mentioned in section 4.3.
 
 
-### 5 FpAnalyser and Batch-Compile (Not Recommend)
+### 3 Other utilities
 
-This part is the instructions for FP-analysis and batch-compile. The script introduced in this part is actually an combination of section 2 and section 4.
-
-We recommend doing FP-analysis (section 2) and batch-compile (section 4) separately. The fP-Analysis is very time-consuming. Thus, saving the `bie` file of each model for the future usage is more convinient.
-
-Back to this section, again, we'll use the `LittleNet` as an example. Just like in the section 4, we need `batch_input_params.json`. But this time, **the fields we need to prepare are different**. Please check the next section.
-
-#### 5.1 Fill the input parameters
-
-As said in section 4, the details of the config can be found in the appendix. You can use the following code to create the `batch_input_params.json` for a walk through.
-
-```json
-{
-    "encryption": {
-        "whether_encryption": false,
-        "encryption mode": 1,
-        "encryption_key": "0x12345678",
-        "key_file": "",
-        "encryption_efuse_key": "0x12345678"
-    },
-    "models": [
-        {
-            "id": 32769,
-            "version": "1",
-            "path": "/data1/LittleNet/LittleNet.onnx",
-            "input_params": "/data1/LittleNet/input_params.json"
-        }
-    ]
-}
-```
-
- We can take a look on what are the differences. Ignore the encryption section which is set to false. The real differences here are that we are giving `onnx` instead of `bie` in the model's `path`, and giving an extra `input_params.json` in a field called `input_params`. This `input_params.json` is the one that we use in section 2. With the onnx and the json, it could run the FP-analysis just like what we do in secion 2, uses the generated `bie` to do batch-compile right after all the FP-analysis is finished.
-
-#### 5.2 Running the programs
-
-For running the FP-analysis and batch-compiler:
-
-```bash
-# For KDP520
-# python /workspace/scripts/fpAnalyserBatchCompile_520.py -t thread_number
-python /workspace/scripts/fpAnalyserBatchCompile_520.py -t 8
-
-# For KDP720
-# python /workspace/scripts/fpAnalyserBatchCompile_720.py -t thread_number
-python /workspace/scripts/fpAnalyserBatchCompile_720.py -t 8
-```
-
-`thread_number`: the number of thread to use
-
-#### 5.3 Get the result
-
-Under `/data1`, you’ll find a folder called `batch_compile`, which contains the output files of batch compile and FP-analysis. There so many outputs but not all of them are useful for the user. Here are the main outputs you may need:
-
-* `/data1/batch_compile/<model_name>.quan.wqbi.bie`: the encrypted result of the model analyzer. It includes the quantize information and the model itself. Can be taken by the compiler and the simulator.
-* `/data1/batch_compile/<model_name>.command.bin`: the compiled binary for the hardware of a single model. You might find one for every model you list in the json.
-* `/data1/batch_compile/<model_name>.setup.bin`: the compiled binary for the hardware of a single model. You might find one for every model you list in the json.
-* `/data1/batch_compile/<model_name>.weight.bin`: the compiled binary for the hardware of a single model. You might find one for every model you list in the json.
-* `/data1/batch_compile/<model_name>.ioinfo.csv`: the hardware IO mapping information of the model. You might find one for every model you list in the json.
-* `/data1/batch_compile/models_520.nef`: the compiled binary with all the models. This file is designed to be loaded by the firmware. *(Only the 520 version script generate this file.)*
-* `/data1/batch_compile/models_720.nef`: the compiled binary with all the models. This file is designed to be loaded by the firmware. *(Only the 720 version script generate this file.)*
-
-### 6 Other utilities
-
-#### 6.1 Convert bin file to png
+#### 3.1 Convert bin file to png
 
 ```bash
 cd /workspace/scripts/utils && python bintoPng.py -i input_rgb565_file_path –o output_png_file_path –he rgb565_height –w rgb565_width -f bin_format
 ```
 
-#### 6.2 Post process
+#### 3.2 Post process
 
 ```bash
 cd /workspace/scripts/utils && python post_process.py -i emulator_result_folder -m model_type
 ```
 
-#### 6.3 Upgrade `input_params.json`
-
-If you have the configuration file from toolchain v0.9.0, you can use the following script to convert the old
-`input_params.json` into a new one.
-
-```bash
-python /workspace/scripts/upgrade_input_params.py old_input_params.json new_input_params.json
-```
-
-#### 6.4 Combine NEF files
+#### 3.3 Combine NEF files
 
 You can combine multiple generated NEF files into one with `/workspace/libs/compiler/kneron_nef_utils`. This is very useful when you already have multiple nef files from different versions of the toolchain. The usage is as below:
 
@@ -296,100 +155,7 @@ In the command above, the nef file list after `-c` are the nef files you want to
 
 ## Appendix
 
-### A. How to configure the `input_params.json`?
-
-By following the above instructions, the `input_params.json` will be saved in `/data1`.
-Please do not change the parameters’ names.
-
-Here is an example JSON with comments. **Please remove all the comments in the real configuration file.**
-
-```json
-{
-    // The basic information of the model needed by the toolchain.
-    "model_info": {
-        // The input model file. If you are not sure about the input names, you can
-        // check it through model visualize tool like [netron](https://netron.app/).
-        // If the configuration is referred by `batch_input_params.json`, this field
-        // will be ignored.
-        "input_onnx_file": "/data1/yolov5s_e.onnx",
-        // A list of the model inputs name with the absolute path of their corresponding
-        // inputs image folders. It is required by FP-analysis.
-        "model_inputs": [{
-            "model_input_name": "data_out_0" ,
-            "input_image_folder": "/data1/100_image/yolov5",
-        }],
-        // Special mode for fp-analysis. Currently available mode:
-        // - default: for most of the models.
-        // - post_sigmoid: recommand for yolo models.
-        // If this option is not present, it uses the 'default' mode.
-        "quantize_mode": "default",
-        // For fp-analysis, remove outliers when calculating max & min. It should be between 0.0 and 1.0.
-        // If not given, default value is 0.999.
-        "outlier": 0.999
-    },
-    // The preprocess method of the input images.
-    "preprocess": {
-        // The image preprocess methods.
-        // Options: `kneron`, `tensorflow`, `yolo`, `caffe`, `pytorch`
-        // `kneron`: RGB/256 - 0.5,
-        // `tensorflow`: RGB/127.5 - 1.0,
-        // `yolo`: RGB/255.0
-        // `pytorch`: (RGB/255. -[0.485, 0.456, 0.406]) / [0.229, 0.224, 0.225]
-        // `caffe`(BGR format) BGR  - [103.939, 116.779, 123.68]
-        // `customized”`: please refer to FAQ question 8
-        "img_preprocess_method": "kneron",
-        // The channel information after the input image is preprocessed.
-        // Options: RGB, BGR, L
-        // L means single channel.
-        "img_channel": "RGB",
-        // The radix information for the npu image process.
-        // The formula for radix is 7 – ceil(log2 (abs_max)).
-        // For example, if the image processing method we utilize is "kneron",
-        // the related image processing formula is "kneron": RGB/256 - 0.5,
-        // and the processed value range will be (-0.5, 0.5).
-        // abs_max = max(abs(-0.5), abs(0.5)) = 0.5
-        // radix = 7 – ceil(log2(abs_max)) = 7 - (-1) = 8
-        "radix": 8,
-        // [optional]
-        // Indicates whether or not to keep the aspect ratio. Default is true.
-        "keep_aspect_ratio": true,
-        // [optioanl]
-        // This is the option for the mode of adding paddings, and it will be utilized only
-        // when `keep_aspect_ratio` is true. Default is 1.
-        // Options: 0, 1
-        // 0 – If the original width is too small, the padding will be added at both right
-        //     and left sides equally; if the original height is too small, the padding
-        //     will be added at both up and down sides equally.
-        // 1 – If the original width is too small, the padding will be added at the right
-        //     side only, if the original height is too small, the padding will be only
-        //     added at the down side.
-        "pad_mode": 1,
-        // [optional]
-        // The parameters for cropping image. And it has four sub parameters. Default are 0s.
-        // -crop_x, cropy, the left cropping point coordinate.
-        // -crop_y, cropy, the up cropping point coordinate.
-        // -crop_h, the width of the cropped image.
-        // -crop_w, the height of the cropped image.
-        "p_crop": {
-            "crop_x": 0,
-            "crop_y": 0,
-            "crop_w": 0,
-            "crop_h": 0
-        }
-    },
-    // [optional]
-    // A list of the model inputs name with the absolute path of their corresponding
-    // input images. It is used by the hardware validator. If this field is not given,
-    // a random image for each input will be picked up from the `input_image_folder`
-    // in the `model_info`.
-    "simulator_img_files": [{
-            "model_input_name": "data_out" ,
-            "input_image": "/data1/100_image/yolov5/a.jpg",
-    }]
-}
-```
-
-### B. How to configure the `batch_input_params.json`?
+### A. How to configure the `batch_input_params.json`?
 
 By following the above instructions, the `batch_input_params.json` will be saved under `/data1`.
 Please do not change the parameters’ names.
@@ -435,16 +201,12 @@ Here is an example JSON with comments. **Please remove all the comments in the r
             // [optional]
             // Only needed when you are running batchCompile_*.py with an onnx.
             "radix_json": ".json",
-            // Required when you are running fpAnalyserBatchCompile. This configuration
-            // file is used to provide information for FP-analysis. Please check FAQ 1
-            // for details.
-            "input_params": "/data1/input_params.json"
         }
     ]
 }
 ```
 
-### C. What’s the meaning of IP Evaluator’s output?
+### B. What’s the meaning of IP Evaluator’s output?
 
 * estimate FPS float => average Frame Per Second
 * total time => total time duration for single image inference on NPU
@@ -454,21 +216,16 @@ Here is an example JSON with comments. **Please remove all the comments in the r
 * total theoretical convolution time => theoretically minimum total run time of the model when MAC efficiency is 100%
 * MAC efficiency to total time => time ratio of the theoretical convolution time to the total time
 
-### D. What’s the meaning of the output files?
+### C. What’s the meaning of the output files?
 
 * `command.bin`: the compiled binary for the hardware.
 * `setup.bin`: the compiled binary for the hardware.
 * `weight.bin`: the compiled binary for the hardware.
-* `ioinfo.csv`: the hardware IO mapping information of the model.
+* `ioinfo.csv`: the hardware IO mapping information of the model. (520)
+* `ioinfo.json`: the hardware IO mapping information of the model.
 * `ip_eval_prof.txt`:  the IP evaluation report, which is the estimate performance of your model on the NPU. *(Only the 520 version script generate this file.)*
 * `ProfileResult.txt`:  the IP evaluation report, which is the estimate performance of your model on the NPU. *(Only the 720 version script generate this file.)*
 * `<model_name>.quan.wqbi.bie`: the encrypted result of the model analyzer. It includes the quantize information and the model itself. Can be taken by the compiler and the simulator.
 * `models_520/720.nef`: the compiled binary with all the models. This file is designed to be loaded by the firmware.
 
 If you find the cpu node in `ioinfo.csv`, whose format is `c,\**,**`”`, you need to implement and register this function in SDK.
-
-
-#### E. How to use customized methods for image preprocess?
-
-1. Configure the `input_params.json`, and fill the value of `img_preprocess_method` as `customized`;
-2. edit the file `/workspace/scripts/utils/img_preprocess.py`, search for the text `#this is the customized part` and add your customized image preprocess method there.

--- a/docs/toolchain/appendix/converters.md
+++ b/docs/toolchain/appendix/converters.md
@@ -302,9 +302,12 @@ For existed onnx models with the previous version of the opset, we provide the f
 Note that after running any of the following scripts, you may still need to run `onnx2onnx.py`.
 
 ```bash
-# For ONNX 1.3 to 1.4 (opset 7/8 to opset 9):
-python /workspace/libs/ONNX_Convertor/optimizer_scripts/onnx1_3to1_4.py input.onnx output.onnx
+# For ONNX opset 8 to opset 9:
+python /workspace/libs/ONNX_Convertor/optimizer_scripts/opset_8_to_9.py input.onnx output.onnx
 
-# For ONNX 1.4 to 1.6 (opset 9 to opset 11):
-python /workspace/libs/ONNX_Convertor/optimizer_scripts/onnx1_4to1_6.py input.onnx output.onnx
+# For ONNX opset 9 to opset 11:
+python /workspace/libs/ONNX_Convertor/optimizer_scripts/opset_9_to_11.py input.onnx output.onnx
+
+# For ONNX opset 10 to opset 11:
+python /workspace/libs/ONNX_Convertor/optimizer_scripts/opset_10_to_11.py input.onnx output.onnx
 ```

--- a/docs/toolchain/appendix/history.md
+++ b/docs/toolchain/appendix/history.md
@@ -2,6 +2,9 @@
 
 ## Manual History Version
 
+* [v0.20.2](https://github.com/kneron/document_center/releases/tag/v0.20.2)
+* [v0.20.1](https://github.com/kneron/document_center/releases/tag/v0.20.1)
+* [v0.20.0](https://github.com/kneron/document_center/releases/tag/v0.20.0)
 * [v0.19.0](../history/manual_v0.19.0.pdf)
 * [v0.18.2](../history/manual_v0.18.2.pdf)
 * [v0.17.2](../history/manual_v0.17.2.pdf)
@@ -21,6 +24,15 @@
 
 ## Toolchain Change log
 
+* **[v0.21.0]**
+    * **Change input format from channel last to the same input shape of ONNX.**
+    * **Change compiler generated `ioinfo.csv` into `ioinfo.json` for platforms other than 520.**
+    * **Remove deprecated command line scripts, e.g. fpAnalyserCompilerIpevaluator_520.py, fpAnalyserBatchCompile_520.py.**
+    * Add html report for `analysis` API.
+    * Add helper utilities under compiler folder.
+    * Add `parallel` and `w3m` into docker environment.
+    * Bug fixes.
+    * Documentation updates.
 * **[v0.20.2]**
     * Fix combining nef error.
 * **[v0.20.1]**

--- a/docs/toolchain/manual_2_deploy.md
+++ b/docs/toolchain/manual_2_deploy.md
@@ -37,8 +37,8 @@ You can use the following command to pull the latest toolchain docker.
 docker pull kneron/toolchain:latest
 ```
 
-Note that the latest toolchain version v0.20.2. You can find the version of the toolchain in
-`/workspace/version.txt` inside the docker. If you find your toolchain is earlier than v0.20.0, you may need to find the
+Note that the latest toolchain version v0.21.0. You can find the version of the toolchain in
+`/workspace/version.txt` inside the docker. If you find your toolchain is earlier than v0.21.0, you may need to find the
 document from the [manual history](appendix/history.md).
 
 ## 2.3. Toolchain Docker Overview
@@ -77,12 +77,13 @@ their usage:
 |-- examples            # Example for the workflow, will be used later.
 |-- libs                # The libraries
 |   |-- ONNX_Convertor  # ONNX Converters and optimizer scripts, will be discussed in section 3.
+|   |-- c_sim_[version] # Hardware simulators for specific hardware versions.
 |   |-- compiler        # Compiler for the hardware and the IP evaluator to infer the performance.
 |   |-- dynasty         # Simulator which only simulates the calculation.
-|   |-- fpAnalyser      # Analyze the model and provide fixed point information.
-|   `-- hw_c_sim        # Hardware simulator which simulate all the hardware behaviours.
+|   `-- fpAnalyser      # Analyze the model and provide fixed point information.
 |-- miniconda           # Environment
 |-- scripts             # Scripts to run the tools, will be discussed in section 3.
+|-- webgui              # Web GUI for the toolchain. Please check appendix for details.
 `-- version.txt
 ```
 

--- a/docs/toolchain/manual_3_onnx.md
+++ b/docs/toolchain/manual_3_onnx.md
@@ -498,7 +498,7 @@ The python code would be like:
 inf_results = ktc.kneron_inference(input_data, onnx_file="/workspace/examples/mobilenetv2/mobilenetv2_zeroq.origin.onnx", input_names=["images"])
 ```
 
-In the code above, `inf_results` is a list of result data. `onnx_file` is the path to the input onnx. `input_data` is a list of input data after preprocess. It should be in channel last format (HWC). The `input_names` is a list of string mapping the input data to specific input on the graph using the sequence. **Note that the input should have the same dimension as the model but in channel last format (HWC).**
+In the code above, `inf_results` is a list of result data. `onnx_file` is the path to the input onnx. `input_data` is a list of input data after preprocess. It should be the same shape as in the onnx. The `input_names` is a list of string mapping the input data to specific input on the graph using the sequence. **Note that the input should have the same shape as in the onnx (usually NCHW).**
 
 Here we provide a very simple preprocess function which only do the resize and normalization. Then, the full code of this section would be:
 
@@ -510,7 +510,8 @@ def preprocess(input_file):
     image = Image.open(input_file)
     image = image.convert("RGB")
     img_data = np.array(image.resize((224, 224), Image.BILINEAR)) / 255
-    img_data = np.transpose(img_data, (1, 0, 2))
+    img_data = np.transpose(img_data, (2, 1, 0))
+    img_data = np.expand_dims(img_data, 0)
     return img_data
 
 input_data = [preprocess("/workspace/examples/mobilenetv2/images/000007.jpg")]

--- a/docs/toolchain/manual_4_bie.md
+++ b/docs/toolchain/manual_4_bie.md
@@ -22,14 +22,12 @@ Args:
 * output_bie (str, optional): path to the output bie file. Defaults to "/data1/output.bie".
 * threads (int, optional): multithread setting. Defaults to 4.
 * quantize_mode (str, optional): quantize_mode setting. Currently support default and post_sigmoid. Defaults to "default".
-* outlier (float, optional): DEPRECAETED. Please use percentage instead.
 * datapath_range_method (str, optional): could be 'mmse' or 'percentage. mmse: use snr-based-range method. percentage: use arbitary percentage. Default to 'percentage'.
 * percentile (float, optional): used under 'mmse' mode. The range to search. The larger the value, the larger the search range, the better the performance but the longer the simulation time. Defaults to 0.001,
 * outlier_factor (float, optional): used under 'mmse' mode. The factor applied on outliers. For example, if clamping data is sensitive to your model, set outlier_factor to 2 or higher. Higher outlier_factor will reduce outlier removal by increasing range. Defaults to 1.0.
 * percentage (float, optional): used under 'percentage' mode. Suggest to set value between 0.999 and 1.0. Use 1.0 for detection models. Defaults to 0.999.
 * bitwidth_mode (str, optioanl): could be "8" or "16". Try "16" if quantized model has performance degradation. Defaults to "8".
 * fm_cut (str, optional): could be "default" or "deep_search". Get a better image cut method through deep search, so as to improve the efficiency of our NPU. Defaults to "default".
-* skip_verify (bool, optional): DEPRECAETED. Skip the verification when running analysis. Same behavious as `mode=1`. Defaults to None(True).
 * mode (int, optional): running mode for the analysis. Defaults to 1.
     - 0: run ip_evaluator only. This mode will not output bie file.
     - 1: run knerex (for quantization) only.
@@ -56,8 +54,15 @@ input_images = [preprocess("/workspace/examples/mobilenetv2/images/" + image_nam
 # We need to prepare a dictionary, which mapping the input name to a list of preprocessed arrays.
 input_mapping = {"images": input_images}
 
-# Quantization without fine-tuning
-bie_path = km.analysis(input_mapping, output_bie = None, threads = 4)
+# Quantization with only deep_search enabled.
+bie_path = km.analysis(input_mapping, output_bie = None, threads = 4, fm_cut='deep_search')
+```
+
+Since toolchain v0.21.0, the analysis step also generates a detailed report in html format. You can find it under
+`/data1/kneron_flow/model_fx_report.html`. You can view it using the command line web browser included in the toolchain:
+
+```bash
+w3m /data1/kneron_flow/model_fx_report.html
 ```
 
 ## 4.2. E2E Simulator Check (Fixed Point)
@@ -72,7 +77,7 @@ The python code would be like:
 fixed_results = ktc.kneron_inference(input_data, bie_file=bie_path, input_names=["data_out"], platform=720)
 ```
 
-The usage is almost the same as using onnx. In the code above, `inf_results` is a list of result data. `bie_file` is the path to the input bie. `input_data` is a list of input data after preprocess the `input_names` is a list of model input name. The requirement is the same as in section 3.3. If your platform is not 520, you may need an extra parameter `platform`, e.g. `platform=720` or `platform=530`.
+The usage is almost the same as using onnx. In the code above, `inf_results` is a list of result data. `bie_file` is the path to the input bie. `input_data` is a list of input data after preprocess the `input_names` is a list of model input name. The requirement is the same as in section 3.3. If your platform is not 520, you need an extra parameter `platform`, e.g. `platform=720` or `platform=530`.
 
 As mentioned above, we do not provide any postprocess. In reality, you may want to have your own postprocess function in Python, too.
 

--- a/docs/toolchain/manual_5_nef.md
+++ b/docs/toolchain/manual_5_nef.md
@@ -62,7 +62,8 @@ def preprocess_2(input_file):
     image = Image.open(input_file)
     image = image.convert("RGB")
     img_data = np.array(image.resize((112, 96), Image.BILINEAR)) / 255
-    img_data = np.transpose(img_data, (1, 0, 2))
+    img_data = np.transpose(img_data, (2, 1, 0))
+    img_data = np.expand_dims(img_data, 0)
     return img_data
 
 input_images_2 = [
@@ -129,3 +130,5 @@ Here is an usage example. Suppose you have three 520 nef files: `/data1/model_32
 #[Note] The nef files in this example is not really provided.
 ktc.combine_nef(['/data1/model_32769.nef', '/data1/model_32770.nef', '/data1/model_32771.nef'], output_path = "/data1/combined")
 ```
+
+**Please note that nef files for 720 hardware generated using the default configuration after toolchain v0.20.0 cannot be combined with the nef files generated previously. This is caused by the default setting for flatbuffer has been changed from False to True for the 720 hardware.**


### PR DESCRIPTION
Remove description of removed command line scripts.
Change description for model updates in converter.
Add history manual link for v0.20.*